### PR TITLE
Disallow squashing in PRs

### DIFF
--- a/standards/commit.md
+++ b/standards/commit.md
@@ -44,7 +44,7 @@ You MUST commit and push all of your changes before you leave for the end of the
 ## Branch History
 You MAY NOT squash changes in a PR for internal projects. DO NOT squash changes for our open source projects unless asked to do so. Squashing removes our ability to see what has been changed during a PR.
 
-You also MAY NOT, unless otherwise specified, ammend a commit and force push it once a PR has been opened.
+You also MAY NOT, unless otherwise specified, amend a commit and force push it once a PR has been opened.
 
 ## Can it be merged?
 A branch SHOULD NOT be merged unless all tests pass. If a test fails, but falls out of the scope of the branch, it should be discussed with the team lead as to whether or not to fix it inside the current branch.

--- a/standards/commit.md
+++ b/standards/commit.md
@@ -44,6 +44,8 @@ You MUST commit and push all of your changes before you leave for the end of the
 ## Branch History
 You MAY NOT squash changes in a PR for internal projects. DO NOT squash changes for our open source projects unless asked to do so. Squashing removes our ability to see what has been changed during a PR.
 
+You also MAY NOT, unless otherwise specified, ammend a commit and force push it once a PR has been opened.
+
 ## Can it be merged?
 A branch SHOULD NOT be merged unless all tests pass. If a test fails, but falls out of the scope of the branch, it should be discussed with the team lead as to whether or not to fix it inside the current branch.
 

--- a/standards/commit.md
+++ b/standards/commit.md
@@ -42,8 +42,7 @@ You SHOULD be committing frequently. This does not mean you need to commit every
 You MUST commit and push all of your changes before you leave for the end of the day. If something happens to your laptop or you, the company should not lose access to any changes that were in progress. If you have a work in progress commit, you MUST prefix your commit message with `[WIP]`. An example is `[WIP] Added delete action to UserController.`.
 
 ## Branch History
-You MAY (OPTIONAL) be squash all related changes to a single commit. Commits such as `[WIP]`, `Added return type`, etc.,
-MAY be combined so as to keep the history clean. The decision to enforce or prohibit this is on a per project basis.
+You MAY NOT squash changes in a PR for internal projects. DO NOT squash changes for our open source projects unless asked to do so. Sqaushing removes our ability to see what has been changed during a PR.
 
 ## Can it be merged?
 A branch SHOULD NOT be merged unless all tests pass. If a test fails, but falls out of the scope of the branch, it should be discussed with the team lead as to whether or not to fix it inside the current branch.

--- a/standards/commit.md
+++ b/standards/commit.md
@@ -42,7 +42,7 @@ You SHOULD be committing frequently. This does not mean you need to commit every
 You MUST commit and push all of your changes before you leave for the end of the day. If something happens to your laptop or you, the company should not lose access to any changes that were in progress. If you have a work in progress commit, you MUST prefix your commit message with `[WIP]`. An example is `[WIP] Added delete action to UserController.`.
 
 ## Branch History
-You MAY NOT squash changes in a PR for internal projects. DO NOT squash changes for our open source projects unless asked to do so. Sqaushing removes our ability to see what has been changed during a PR.
+You MAY NOT squash changes in a PR for internal projects. DO NOT squash changes for our open source projects unless asked to do so. Squashing removes our ability to see what has been changed during a PR.
 
 ## Can it be merged?
 A branch SHOULD NOT be merged unless all tests pass. If a test fails, but falls out of the scope of the branch, it should be discussed with the team lead as to whether or not to fix it inside the current branch.


### PR DESCRIPTION
This does not prohibit those who can squash to do a Squash and Merge. It only prevents developers from doing so in a PR.