### PR TITLE
Capitalize JavaScript word

### DIFF
--- a/standards/javascript.md
+++ b/standards/javascript.md
@@ -1,14 +1,14 @@
-Linio Javascript Coding Standard
+Linio JavaScript Coding Standard
 -------------------------
 
 This guide links to [AIRBNB](https://github.com/airbnb/javascript).
-Linio does not maintain it's own Javascript standards.
-Instead, we choose to utilize the well written and founded Airbnb javascript
+Linio does not maintain it's own JavaScript standards.
+Instead, we choose to utilize the well written and founded Airbnb JavaScript
 standards.
 
 The intent of this guide is to reduce cognitive friction when scanning code
 from different authors. It does so by enumerating a shared set of rules and
-expectations about how to format Javascript code.
+expectations about how to format JavaScript code.
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be


### PR DESCRIPTION
Following the JavaScript Style Guide from AIRBNB the correct word is "JavaScript".