### PR TITLE
Updated the php-cs-fixer standards.

### DIFF
--- a/php-cs-fixer/.php_cs
+++ b/php-cs-fixer/.php_cs
@@ -7,13 +7,28 @@ $finder = PhpCsFixer\Finder::create()
 return PhpCsFixer\Config::create()
     ->setRules([
         '@Symfony' => true,
-        'concat_space' => ['spacing' => 'one'],
         'array_syntax' => ['syntax' => 'short'],
-        'ordered_imports' => true,
-        'pre_increment' => false,
-        'phpdoc_order' => true,
         'blank_line_after_opening_tag' => true,
+        'concat_space' => ['spacing' => 'one'],
+        'declare_strict_types' => true,
+        'is_null' => ['use_yoda_style' => false],
+        'list_syntax' => ['syntax' => 'short'],
+        'method_argument_space' => ['ensure_fully_multiline' => true],
+        'modernize_types_casting' => true,
+        'no_multiline_whitespace_before_semicolons' => true,
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'ordered_imports' => true,
         'phpdoc_align' => false,
+        'phpdoc_order' => true,
+        'php_unit_construct' => true,
+        'php_unit_dedicate_assert' => true,
+        'pre_increment' => false,
+        'single_line_comment_style' => true,
+        'ternary_to_null_coalescing' => true,
+        'yoda_style' => false,
+        'void_return' => true,
     ])
     ->setFinder($finder)
-    ->setUsingCache(true);
+    ->setUsingCache(true)
+    ->setRiskyAllowed(true);


### PR DESCRIPTION
This is nearly the same as what is used in shop-front other than I
remove the ordered class elements fixer. That should be something each
project decides on.